### PR TITLE
Updating listStatus to return json

### DIFF
--- a/src/webhdfs.js
+++ b/src/webhdfs.js
@@ -55,7 +55,7 @@ WebHDFSClient.prototype.del = function (path, options, callback) {
 WebHDFSClient.prototype.listStatus = function (path, callback) {
     
     // format request args
-    var args = { uri: this.base_url + path, qs: { op: 'liststatus' } }
+    var args = { json:true, uri: this.base_url + path, qs: { op: 'liststatus' } }
     
     // send http request
     request.get(args, function (error, response, body) {


### PR DESCRIPTION
I noticed when I was calling listStatus to list my directories that the mime type on the request was not specified and so the result was not coming back as parsable json.  
