### PR TITLE
Added class for Remote Exceptions and used it for exception handling 

### DIFF
--- a/src/remoteexception.js
+++ b/src/remoteexception.js
@@ -1,0 +1,19 @@
+function RemoteException( message, exception ){
+    if(typeof(message) == 'object' && 'RemoteException' in message){
+        this.fromResponseException(message.RemoteException);
+    }
+    else if(typeof(message) == 'string'){
+        this.exception = exception || '_UnknownRemoteException';
+        this.message = message;
+    }
+}
+
+RemoteException.prototype = new Error();
+RemoteException.prototype.constructor = RemoteException;
+
+RemoteException.prototype.fromResponseException = function(re){
+    this.exception = re.exception;
+    this.message = re.message;
+}
+
+module.exports = RemoteException;

--- a/src/webhdfs.js
+++ b/src/webhdfs.js
@@ -1,6 +1,7 @@
 var querystring = require('querystring'),
     request = require('request'),
-    _ = require('underscore');
+    _ = require('underscore'),
+    RemoteException = exports.RemoteException = require('./remoteexception.js');
 
 
 var WebHDFSClient = exports.WebHDFSClient = function (options) {
@@ -57,8 +58,9 @@ WebHDFSClient.prototype.del = function (path, hdfsoptions, requestoptions, callb
         if (error) return callback(error);
         
         // exception handling
-        if ('RemoteException' in body)
-            return callback(new Error(body.RemoteException.message));
+        if ('RemoteException' in body){
+            return callback(new RemoteException(body));
+        }
         
         // execute callback
         return callback(null, body.boolean);
@@ -101,6 +103,11 @@ WebHDFSClient.prototype.listStatus = function (path, hdfsoptions, requestoptions
         // forward request error
         if (error) return callback(error);
         
+        // exception handling
+        if ('RemoteException' in body){
+            return callback(new RemoteException(body));
+        }
+
         // execute callback
         return callback(null, body.FileStatuses.FileStatus)
         
@@ -144,8 +151,9 @@ WebHDFSClient.prototype.getFileStatus = function (path, hdfsoptions, requestopti
         if (error) return callback(error);
         
         // exception handling
-        if ('RemoteException' in body)
-            return callback(new Error(body.RemoteException.message));
+        if ('RemoteException' in body){
+            return callback(new RemoteException(body));
+        }
         
         // execute callback
         return callback(null, body.FileStatus);
@@ -189,8 +197,9 @@ WebHDFSClient.prototype.getContentSummary = function (path, hdfsoptions, request
         if (error) return callback(error);
         
         // exception handling
-        if ('RemoteException' in body)
-            return callback(new Error(body.RemoteException.message));
+        if ('RemoteException' in body){
+            return callback(new RemoteException(body));
+        }
         
         // execute callback
         return callback(null, body.ContentSummary);
@@ -235,8 +244,9 @@ WebHDFSClient.prototype.getFileChecksum = function (path, hdfsoptions, requestop
         if (error) return callback(error);
         
         // exception handling
-        if ('RemoteException' in body)
-            return callback(new Error(body.RemoteException.message));
+        if ('RemoteException' in body){
+            return callback(new RemoteException(body));
+        }
         
         // execute callback
         return callback(null, body.FileChecksum);
@@ -366,8 +376,9 @@ WebHDFSClient.prototype.rename = function (path, destination, hdfsoptions, reque
         if (error) return callback(error);
         
         // exception handling
-        if ('RemoteException' in body)
-            return callback(new Error(body.RemoteException.message));
+        if ('RemoteException' in body){
+            return callback(new RemoteException(body));
+        }
         
         // execute callback
         return callback(null, body.boolean);
@@ -413,8 +424,9 @@ WebHDFSClient.prototype.mkdirs = function (path, hdfsoptions, requestoptions, ca
         if (error) return callback(error);
         
         // exception handling
-        if ('RemoteException' in body)
-            return callback(new Error(body.RemoteException.message));
+        if ('RemoteException' in body){
+            return callback(new RemoteException(body));
+        }
         
         // execute callback
         return callback(null, body.boolean);


### PR DESCRIPTION
Added class for Remote Exceptions and used it for remote exception handling instead of plain Error objects.

In particular, the remote_exception.exception string is populated from the corresponding property of the response body and can be used by calling code to act on particular exceptions. The constructor is exported for type checking:

```
 webHdfs = require("node-webhdfs"),
 ...
 this._hdfs_client.listStatus(directory, function (err, res) {    
    if(err instanceof webHdfs.RemoteException ){
        if(err.exception == 'FileNotFoundException')
            < act on specific exception class >
    }
...
```

The constructor takes either a message string, exception string couple,  or the service response object as-is.
