### PR TITLE
added high availability functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "request": "^2.45.0",
-    "underscore": "^1.7.0"
+    "lodash": "^4.17.4"
   },
   "devDependencies": {
     "mocha": "^1.21.4",

--- a/test/webhdfs.js
+++ b/test/webhdfs.js
@@ -4,7 +4,44 @@ var should = require('should');
 
 describe('WebHDFSClient', function () {
     
-    var client = new (require('..')).WebHDFSClient({ user: 'ryan' });
+    var client = new (require('..')).WebHDFSClient({
+        "user": "hdfs",
+        "namenode_port": 50070,
+        "path_prefix": "/webhdfs/v1",
+        namenode_host: "c1b5s2.tera4.terascope.io",
+        "namenode_list": ["c1b5s2.tera4.terascope.io", "c1b5s1.tera4.terascope.io"]
+    });
+
+    var client2 = new (require('..')).WebHDFSClient({
+        namenode_host: "endpoint1"
+    });
+
+    var client3 = new (require('..')).WebHDFSClient({
+        namenode_host: "endpoint1",
+        namenode_list: ["endpoint1", "endpoint2"]
+    });
+
+    describe('change endpoint', function () {
+
+        it('should set high_availability to false if a list is not provided', function (done) {
+            client2.should.have.property('base_url', 'http://endpoint1:50070/webhdfs/v1');
+            client2.options.should.have.property('high_availability', false);
+
+            return done()
+        });
+
+        it('should change endpoint if a list is provided', function (done) {
+            client3.should.have.property('base_url', 'http://endpoint1:50070/webhdfs/v1');
+            client3.options.should.have.property('high_availability', true);
+
+            client3._changeNameNodeHost();
+            client3.should.have.property('base_url', 'http://endpoint2:50070/webhdfs/v1');
+
+            return done()
+        });
+
+    });
+    
     
     describe('#mkdirs', function () {
         
@@ -127,7 +164,7 @@ describe('WebHDFSClient', function () {
                 should.not.exist(err);
                 should.exist(data);
                 
-                JSON.parse(data).should.have.property('foo', 'bar');
+              (data).should.have.property('foo', 'bar');
                 
                 return done();
                 


### PR DESCRIPTION
This feature is to add high availability to all api calls. Its native functionality should remain intact as all tests pass. You can optionally pass in a list of namenodes, which will be used alter the base_url if there is a standby exception. If a list is provided then it will attempt to call the function again to the new url.  Example config

{
      "user": "hdfs",
      "namenode_port": 50070,
      "path_prefix": "/webhdfs/v1",
      "namenode_host" : "endpoint1"
      "namenode_list": ["endpoint1", "endpoint2"]
 }