### PR TITLE
Improved HA to work with complete namenode process and server crashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-webhdfs",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A WebHDFS module for Node.js.",
   "author": "Ryan Cole <ryan@rycole.com> (http://rycole.com)",
   "homepage": "https://github.com/ryancole/node-webhdfs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-webhdfs",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "description": "A WebHDFS module for Node.js.",
   "author": "Ryan Cole <ryan@rycole.com> (http://rycole.com)",
   "homepage": "https://github.com/ryancole/node-webhdfs",
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "mocha": "^5.2.0",
+    "nock": "^10.0.6",
     "should": "^4.6.5"
   },
   "repository": {

--- a/src/webhdfs.js
+++ b/src/webhdfs.js
@@ -52,14 +52,9 @@ WebHDFSClient.prototype._changeNameNodeHost = function (callback) {
         this._makeBaseUrl();
         return callback();
     }, this.backoff_period_ms)
-    // let startTime = (new Date()).getTime();
-    // while (((new Date()).getTime() - startTime) < this._backoff_period_ms) {
-    //     // do nothing
-    // }
 };
 
 var _parseResponse = exports._parseResponse = function (self, fnName, args, bodyArgs, callback, justCheckErrors){
-    // var changeNameNodeHost = self._changeNameNodeHost(self[fnName].apply(self, args));
     // forward request error
     return function(error, response, body) {
         // If a namenode process dies the connection will be refused, and if the namenode's server
@@ -73,8 +68,6 @@ var _parseResponse = exports._parseResponse = function (self, fnName, args, body
                         return self[fnName].apply(self, args);
                     });
                     return true;
-                    // self._changeNameNodeHost(self[fnName].apply(self, args));
-                    // return self[fnName].apply(self, args)
                 }
                 else {
                     callback(error);
@@ -97,8 +90,6 @@ var _parseResponse = exports._parseResponse = function (self, fnName, args, body
                 });
                 return true;
                 //change client
-                // self._changeNameNodeHost();
-                // return self[fnName].apply(self, args)
             }
             else {
                 callback(new RemoteException(body));
@@ -150,10 +141,8 @@ WebHDFSClient.prototype.del = function (path, hdfsoptions, requestoptions, callb
             'user.name': this.options.user
         }, hdfsoptions || {})
     }, requestoptions || {});
-
     // send http request
     request.del(args, parseResponse);
-
 };
 
 
@@ -184,10 +173,8 @@ WebHDFSClient.prototype.listStatus = function (path, hdfsoptions, requestoptions
             op: 'liststatus'
         }, hdfsoptions || {})
     }, requestoptions || {});
-
     // send http request
     request.get(args, parseResponse)
-
 };
 
 
@@ -218,10 +205,8 @@ WebHDFSClient.prototype.getFileStatus = function (path, hdfsoptions, requestopti
             op: 'getfilestatus'
         }, hdfsoptions || {})
     }, requestoptions || {});
-
     // send http request
     request.get(args, parseResponse);
-
 };
 
 
@@ -252,10 +237,8 @@ WebHDFSClient.prototype.getContentSummary = function (path, hdfsoptions, request
             op: 'getcontentsummary'
         }, hdfsoptions || {})
     }, requestoptions || {});
-
     // send http request
     request.get(args, parseResponse);
-
 };
 
 
@@ -286,7 +269,6 @@ WebHDFSClient.prototype.getFileChecksum = function (path, hdfsoptions, requestop
             op: 'getfilechecksum'
         }, hdfsoptions || {})
     }, requestoptions || {});
-
     // send http request
     request.get(args, parseResponse);
 };
@@ -320,10 +302,8 @@ WebHDFSClient.prototype.getHomeDirectory = function (hdfsoptions, requestoptions
             'user.name': this.options.user
         }, hdfsoptions || {})
     }, requestoptions || {});
-
     // send http request
     request.get(args, parseResponse);
-
 };
 
 // ref: http://hadoop.apache.org/common/docs/stable1/webhdfs.html#OPEN
@@ -352,10 +332,8 @@ WebHDFSClient.prototype.open = function (path, hdfsoptions, requestoptions, call
             op: 'open'
         }, hdfsoptions || {})
     }, requestoptions || {});
-
     // send http request
     return request.get(args, parseResponse);
-
 };
 
 
@@ -388,10 +366,8 @@ WebHDFSClient.prototype.rename = function (path, destination, hdfsoptions, reque
             'user.name': this.options.user
         }, hdfsoptions || {})
     }, requestoptions || {});
-
     // send http request
     request.put(args, parseResponse);
-
 };
 
 
@@ -423,10 +399,8 @@ WebHDFSClient.prototype.mkdirs = function (path, hdfsoptions, requestoptions, ca
             'user.name': this.options.user
         }, hdfsoptions || {})
     }, requestoptions || {});
-
     // send http request
     request.put(args, parseResponse);
-
 };
 
 
@@ -451,7 +425,6 @@ WebHDFSClient.prototype.append = function (path, data, hdfsoptions, requestoptio
 
     // format request args
     var args = _.defaults({
-
         json: true,
         followRedirect: false,
         uri: this.base_url + path,
@@ -459,12 +432,10 @@ WebHDFSClient.prototype.append = function (path, data, hdfsoptions, requestoptio
             op: 'append',
             'user.name': this.options.user
         }, hdfsoptions || {})
-
     }, requestoptions || {});
 
     // send http request
     request.post(args, function (error, response, body) {
-
        var handled = parseResponse(error, response, body);
        if (handled) {
            // callback already called
@@ -484,7 +455,6 @@ WebHDFSClient.prototype.append = function (path, data, hdfsoptions, requestoptio
 
             // send http request
             request.post(args, function (error, response, body) {
-
                 // forward request error
                 var handled = parseResponse(error, response, body);
                 if (handled) {
@@ -497,7 +467,6 @@ WebHDFSClient.prototype.append = function (path, data, hdfsoptions, requestoptio
                     return callback(new Error('expected http 200: ' + response ? response.body : response));
                 }
             });
-
         } else {
             return callback(new Error('expected redirect'));
         }
@@ -526,21 +495,17 @@ WebHDFSClient.prototype.create = function (path, data, hdfsoptions, requestoptio
 
     // generate query string
     var args = _.defaults({
-
         json: true,
         followRedirect: false,
         uri: this.base_url + path,
         qs: _.defaults({
-
             op: 'create',
             'user.name': this.options.user
-
         }, hdfsoptions || {})
     }, requestoptions || {});
 
     // send http request
     request.put(args, function (error, response, body) {
-
         // forward request error
         parseResponse(error, response, body);
         if (error) {
@@ -553,7 +518,6 @@ WebHDFSClient.prototype.create = function (path, data, hdfsoptions, requestoptio
         }
         // check for expected redirect
         else if (response.statusCode == 307) {
-
             // generate query string
             args = _.defaults({
                 body: data,
@@ -562,7 +526,6 @@ WebHDFSClient.prototype.create = function (path, data, hdfsoptions, requestoptio
 
             // send http request
             request.put(args, function (error, response, body) {
-
                 // forward request error
                 parseResponse(error, response, body);
                 if (error) {
@@ -576,11 +539,8 @@ WebHDFSClient.prototype.create = function (path, data, hdfsoptions, requestoptio
                     return callback(new Error('expected http 201 created'));
                 }
             });
-
         } else {
             return callback(new Error('expected redirect'));
         }
-
     });
-
 };

--- a/test/webhdfs.js
+++ b/test/webhdfs.js
@@ -16,7 +16,6 @@ const nock = require('nock');
 
 describe('WebHDFSClient', function () {
 
-    // never used for actual connection
     const oneNodeClient = new (require('..')).WebHDFSClient({
         namenode_host: endpoint1
     });
@@ -30,7 +29,7 @@ describe('WebHDFSClient', function () {
     // Set up a noop for testing puporses
     twoNodeClient._noop = function (callback) {
         if (callback) return callback();
-        // Adding this to tes the namenode switch inside the response parser
+        // Adding this to test the namenode switch inside the response parser
         return twoNodeClient._checkParsedResponse();
     };
 
@@ -268,7 +267,6 @@ describe('WebHDFSClient', function () {
         it('works properly', function (done) {
             const filePath = '/test/file';
             const newFilePath = '/new/test/file';
-            // const qs = `?op=rename&destination=${newFilePath}&user.name=webuser`;
             const namenodeRequest = nock(nodeOneBase)
                 .put('/webhdfs/v1/test/file?op=rename&destination=%2Fnew%2Ftest%2Ffile&user.name=webuser')
                 .reply(200, {boolean: true})
@@ -276,7 +274,6 @@ describe('WebHDFSClient', function () {
                 should.not.exist(err);
                 should(status).be.exactly(true)
                 return done()
-                //return
             })
         })
     })
@@ -291,7 +288,6 @@ describe('WebHDFSClient', function () {
                 should.not.exist(err);
                 should(response).be.exactly(true)
                 return done()
-                //return
             })
         })
     })

--- a/test/webhdfs.js
+++ b/test/webhdfs.js
@@ -1,248 +1,336 @@
 const username = process.env.HDFS_USERNAME || 'ryan';
-const endpoint1 = process.env.HDFS_NAMENODE_1 || 'localhost';
-const endpoint2 = process.env.HDFS_NAMENODE_2 || '127.0.0.1';
+const endpoint1 = process.env.HDFS_NAMENODE_1 || 'namenode1.lan';
+const endpoint2 = process.env.HDFS_NAMENODE_2 || 'namenode2.lan';
 const homeDir = `/user/${username}`;
 const basePath = process.env.HDFS_BASE_PATH || homeDir;
+const nodeOneBase = `http://${endpoint1}:50070`;
+const nodeTwoBase = `http://${endpoint2}:50070`;
 // endpoint defaults are written differently to verify switching
 
-var should = require('should');
+// This is only needed for testing the response parser
+const webhdfs = require('..');
+
+const should = require('should');
+const nock = require('nock');
 
 
 describe('WebHDFSClient', function () {
 
     // never used for actual connection
-    var oneNodeClient = new (require('..')).WebHDFSClient({
+    const oneNodeClient = new (require('..')).WebHDFSClient({
         namenode_host: endpoint1
     });
 
-    var twoNodeClient = new (require('..')).WebHDFSClient({
+    const twoNodeClient = new (require('..')).WebHDFSClient({
         user: username,
         namenode_host: endpoint1,
         namenode_list: [endpoint1, endpoint2]
     });
 
-    describe('change endpoint', function () {
+    // Set up a noop for testing puporses
+    twoNodeClient._noop = function (callback) {
+        if (callback) return callback();
+        // Adding this to tes the namenode switch inside the response parser
+        return twoNodeClient._checkParsedResponse();
+    };
 
-        it('should set high_availability to false if a list is not provided', function (done) {
-            oneNodeClient.should.have.property('base_url', 'http://' + endpoint1 + ':50070/webhdfs/v1');
-            oneNodeClient.options.should.have.property('high_availability', false);
+    it('should set high_availability to false if a list is not provided', function (done) {
+        oneNodeClient.should.have.property('base_url', nodeOneBase + '/webhdfs/v1');
+        oneNodeClient.options.should.have.property('high_availability', false);
 
-            return done()
-        });
+        return done()
+    });
 
-        it('should change endpoint if a list is provided', function (done) {
-            twoNodeClient.should.have.property('base_url', 'http://' + endpoint1 + ':50070/webhdfs/v1');
+    describe('high-availability capability', function () {
+        it('should detect the first failover', function (done) {
+            function checkBackOffSettings() {
+                twoNodeClient.should.have.property('_switchedNameNodeClient', true);
+                twoNodeClient.should.have.property('base_url', nodeTwoBase + '/webhdfs/v1');
+                return done()
+            }
+            twoNodeClient.should.have.property('base_url', nodeOneBase + '/webhdfs/v1');
+            twoNodeClient.should.have.property('_switchedNameNodeClient', false);
             twoNodeClient.options.should.have.property('high_availability', true);
-
-            twoNodeClient._changeNameNodeHost();
-            twoNodeClient.should.have.property('base_url', 'http://' + endpoint2 + ':50070/webhdfs/v1');
-
+            twoNodeClient.options.should.have.property('default_backoff_period_ms', 500);
+            twoNodeClient._changeNameNodeHost(checkBackOffSettings);
+        });
+        it('should increase backoff exponentially for repeated failovers', function (done) {
+            function checkBackOffSettings() {
+                twoNodeClient.should.have.property('_switchedNameNodeClient', true);
+                twoNodeClient.should.have.property('_backoff_period_ms', 1000);
+                twoNodeClient.should.have.property('base_url', nodeOneBase + '/webhdfs/v1');
+                return done()
+            }
+            twoNodeClient._switchedNameNodeClient = true;
+            // twoNodeClient.base_url = nodeOneBase + ':50070/webhdfs/v1';
+            twoNodeClient.should.have.property('base_url', nodeTwoBase + '/webhdfs/v1');
+            twoNodeClient.should.have.property('_switchedNameNodeClient', true);
+            twoNodeClient.options.should.have.property('high_availability', true);
+            // return done()
+            twoNodeClient._changeNameNodeHost(checkBackOffSettings);
+        });
+    });
+    describe('_parseResponse', function () {
+        it('executes a provided callback and resets backoff settings when there are no errors', function (done) {
+            function checkParsedResponse (nullVal, bodyVal) {
+                should(nullVal).be.exactly(null);
+                should(bodyVal).be.exactly('ayo');
+                twoNodeClient.should.have.property('base_url', nodeOneBase + '/webhdfs/v1');
+                twoNodeClient.should.have.property('_switchedNameNodeClient', false);
+                twoNodeClient.should.have.property('_backoff_period_ms', 500);
+                return done();
+            }
+            twoNodeClient.should.have.property('_switchedNameNodeClient', true);
+            twoNodeClient.should.have.property('base_url', nodeOneBase + '/webhdfs/v1');
+            twoNodeClient.should.have.property('_backoff_period_ms', 1000);
+            const parseResponse = webhdfs._parseResponse(twoNodeClient, '_noop', undefined, 'val1', checkParsedResponse, false)
+            parseResponse(undefined, undefined, {val1: 'ayo'});
+        });
+        it('just checks for errors', function (done) {
+            twoNodeClient.should.have.property('_switchedNameNodeClient', false);
+            twoNodeClient.should.have.property('base_url', nodeOneBase + '/webhdfs/v1');
+            const parseResponse = webhdfs._parseResponse(twoNodeClient, undefined, undefined, undefined, undefined, true)
+            should(parseResponse(undefined, undefined, undefined)).be.exactly(false);
             return done()
         });
-
-    });
-
-    describe('#getHomeDirectory()', function () {
-        
-        it('should get the home directory', function (done) {
-            
-            twoNodeClient.getHomeDirectory(function (err, status) {
-                
-                should.not.exist(err);
-                should.exist(status);
-                status.should.eql(homeDir);
-                
+        it('handles an hdfs StandbyException properly', function (done) {
+            twoNodeClient._checkParsedResponse = function () {
+                twoNodeClient.should.have.property('_switchedNameNodeClient', true);
+                twoNodeClient.should.have.property('_backoff_period_ms', 500);
+                twoNodeClient.should.have.property('base_url', nodeTwoBase + '/webhdfs/v1');
                 return done();
-                
-            });
-            
-        });
-        
-    });
-    
-    describe('#mkdirs', function () {
-        
-        it('should return `true` if the directory was created', function (done) {
-            
-            twoNodeClient.mkdirs(basePath + '/test', function (err, success) {
-                
-                should.not.exist(err);
-                should.exist(success);
-                
-                success.should.be.true;
-                
+            }
+            twoNodeClient.should.have.property('_switchedNameNodeClient', false);
+            twoNodeClient.should.have.property('_backoff_period_ms', 500);
+            const parseResponse = webhdfs._parseResponse(twoNodeClient, '_noop', undefined, undefined, undefined, false)
+            const result = parseResponse(undefined, undefined, {RemoteException: {exception: 'StandbyException'}});
+            should(result).be.exactly(true);
+        })
+        it('handles a generic error properly', function (done) {
+            function checkParsedResponse(error) {
+                should(error).be.exactly(42);
+                return done()
+            }
+            twoNodeClient.should.have.property('_switchedNameNodeClient', true);
+            twoNodeClient.should.have.property('base_url', nodeTwoBase + '/webhdfs/v1');
+            twoNodeClient.should.have.property('_backoff_period_ms', 500);
+            const parseResponse = webhdfs._parseResponse(twoNodeClient, undefined, undefined, undefined, checkParsedResponse, false)
+            parseResponse(42, undefined, undefined);
+        })
+        it('handles a refused connection properly (symptom of dead active namenode process)', function (done) {
+            twoNodeClient._checkParsedResponse = function () {
+                twoNodeClient.should.have.property('_switchedNameNodeClient', true);
+                twoNodeClient.should.have.property('_backoff_period_ms', 1000);
+                twoNodeClient.should.have.property('base_url', nodeOneBase + '/webhdfs/v1');
                 return done();
-                
-            });
-            
-        });
-        
-    });
-    
-    describe('#getFileStatus()', function () {
-        
-        it('should return information about the directory', function (done) {
-            
-            twoNodeClient.getFileStatus(basePath + '/test', function (err, status) {
-                
-                should.not.exist(err);
-                should.exist(status);
-                
-                status.should.have.property('type', 'DIRECTORY');
-                
+            }
+            twoNodeClient.should.have.property('_switchedNameNodeClient', true);
+            twoNodeClient.should.have.property('_backoff_period_ms', 500);
+            const parseResponse = webhdfs._parseResponse(twoNodeClient, '_noop', undefined, undefined, undefined, false)
+            const result = parseResponse({code: 'ECONNREFUSED'}, undefined, undefined);
+            should(result).be.exactly(true);
+        })
+        it('handles a not found connection error properly (symptom of dead active namenode server)', function (done) {
+            twoNodeClient._checkParsedResponse = function () {
+                twoNodeClient.should.have.property('_switchedNameNodeClient', true);
+                twoNodeClient.should.have.property('_backoff_period_ms', 2000);
+                twoNodeClient.should.have.property('base_url', nodeTwoBase + '/webhdfs/v1');
                 return done();
-                
-            });
-            
-        });
-        
-    });
-    
-    describe('#create()', function () {
-        
-        it('should return the path to the new file', function (done) {
-            
-            twoNodeClient.create(basePath + '/test/foo.txt', 'foo bar', function (err, path) {
-                
-                should.not.exist(err);
-                should.exist(path);
-                
+            }
+            twoNodeClient.should.have.property('_switchedNameNodeClient', true);
+            twoNodeClient.should.have.property('_backoff_period_ms', 1000);
+            const parseResponse = webhdfs._parseResponse(twoNodeClient, '_noop', undefined, undefined, undefined, false)
+            const result = parseResponse({code: 'ENOTFOUND'}, undefined, undefined);
+            should(result).be.exactly(true);
+        })
+        it('handles a not found connection error properly (when HA is not configured)', function (done) {
+            function checkParsedResponse (error) {
+                should(error.code).be.exactly('ENOTFOUND');
                 return done();
-                
-            });
-            
-        });
-        
-    });
-
-    describe('#append()', function () {
-        
-        it('should add to the file', function (done) {
-            
-            twoNodeClient.append(basePath + '/test/foo.txt', ' baz', function (err, path) {
-                
-                should.not.exist(err);
-                should.exist(path);
-                
+            }
+            const parseResponse = webhdfs._parseResponse(oneNodeClient, '_noop', undefined, undefined, checkParsedResponse, false)
+            const result = parseResponse({code: 'ENOTFOUND'}, undefined, undefined);
+            should(result).be.exactly(true);
+        })
+        it('handles a generic "RemmoteException" properly', function (done) {
+            function checkParsedResponse (error) {
+                should(typeof(error)).be.exactly('object')
                 return done();
-                
-            });
-            
-        });
-        
+            }
+            const parseResponse = webhdfs._parseResponse(oneNodeClient, undefined, undefined, undefined, checkParsedResponse, false)
+            const result = parseResponse(undefined, undefined, {RemoteException: 'Error!'});
+            should(result).be.exactly(true);
+        })
     });
-    
-    describe('#rename()', function () {
-        
-        it('should return `true` if the file was renamed', function (done) {
-            
-            twoNodeClient.rename(basePath + '/test/foo.txt', basePath + '/test/bar.txt', function (err, success) {
-                
+    describe('hdfs "delete"', function () {
+        it('works properly', function (done) {
+            const filePath = '/test/file';
+            const qs = '?op=delete&user.name=webuser';
+            const namenodeRequest= nock(nodeOneBase)
+                .delete(`/webhdfs/v1${filePath}${qs}`)
+                .reply(200, {boolean: true})
+            oneNodeClient.del(filePath, function (err, response) {
                 should.not.exist(err);
-                should.exist(success);
-                
-                success.should.be.true;
-                
-                return done();
-                
-            });
-            
-        });
-        
-    });
-    
-    describe('#getContentSummary()', function () {
-        
-        it('should return summary of directory content', function (done) {
-            
-            twoNodeClient.getContentSummary(basePath + '/test', function (err, summary) {
-                
+                should(response).be.exactly(true)
+                return done()
+            })
+        })
+    })
+    describe('hdfs "listStatus"', function () {
+        it('works properly', function (done) {
+            const fileStatus = '{"FileStatuses": {"FileStatus": [{"some": "file details"},{"some": "other file details"}]}}'
+            const filePath = '/test/file';
+            const qs = '?op=liststatus';
+            const namenodeRequest= nock(nodeOneBase)
+                .get(`/webhdfs/v1${filePath}${qs}`)
+                .reply(200, fileStatus)
+            oneNodeClient.listStatus(filePath, function (err, response) {
                 should.not.exist(err);
-                should.exist(summary);
-                
-                summary.should.have.property('fileCount', 1);
-                
-                return done();
-                
-            });
-            
-        });
-        
-    });
-
-    describe('#listStatus()', function () {
-        
-        it('should list files in a directory', function (done) {
-            
-            twoNodeClient.listStatus(basePath + '/test', function (err, status) {
-                
+                should(response.length).be.exactly(2)
+                return done()
+            })
+        })
+    })
+    describe('hdfs "getFileStatus"', function () {
+        it('works properly', function (done) {
+            const fileStatus = '{"FileStatus": {"accessTime": 42}}'
+            const filePath = '/test/file';
+            const qs = '?op=getfilestatus';
+            const namenodeRequest = nock(nodeOneBase)
+                .get(`/webhdfs/v1${filePath}${qs}`)
+                .reply(200, fileStatus)
+            oneNodeClient.getFileStatus(filePath, function (err, response) {
                 should.not.exist(err);
-                should.exist(status);
-                status.map(f => f.pathSuffix).should.containEql('bar.txt');
-                
-                return done();
-                
-            });
-            
-        });
-        
-    });
-    
-    describe('#getFileChecksum()', function () {
-        
-        it('should return a file checksum', function (done) {
-            
-            twoNodeClient.getFileChecksum(basePath + '/test/bar.txt', function (err, checksum) {
-                
+                should(response.accessTime).be.exactly(42)
+                return done()
+            })
+        })
+    })
+    describe('hdfs "getContentSummary"', function () {
+        it('works properly', function (done) {
+            const contentSummary = '{"ContentSummary": {"directoryCount": 7}}'
+            const filePath = '/test/file';
+            const qs = '?op=getcontentsummary';
+            const namenodeRequest = nock(nodeOneBase)
+                .get(`/webhdfs/v1${filePath}${qs}`)
+                .reply(200, contentSummary)
+            oneNodeClient.getContentSummary(filePath, function (err, response) {
                 should.not.exist(err);
-                should.exist(checksum);
-
-                checksum.should.have.property('algorithm', 'MD5-of-0MD5-of-512CRC32C');
-                
-                return done();
-                
-            });
-            
-        });
-        
-    });
-    
-    describe('#open()', function () {
-        
-        it('should return the files content', function (done) {
-            
-            twoNodeClient.open(basePath + '/test/bar.txt', function (err, data) {
-                
+                should(response.directoryCount).be.exactly(7)
+                return done()
+            })
+        })
+    })
+    describe('hdfs "getFileChecksum"', function () {
+        it('works properly', function (done) {
+            const fileChecksum = '{"FileChecksum": {"length": 42}}'
+            const filePath = '/test/file';
+            const qs = '?op=getfilechecksum';
+            const namenodeRequest = nock(nodeOneBase)
+                .get(`/webhdfs/v1${filePath}${qs}`)
+                .reply(200, fileChecksum)
+            oneNodeClient.getFileChecksum(filePath, function (err, response) {
                 should.not.exist(err);
-                should.exist(data);
-                
-                data.should.eql('foo bar baz');
-                
-                return done();
-                
-            });
-            
-        });
-        
-    });
-    
-    describe('#del()', function () {
-        
-        it('should return `true` if the directory was deleted', function (done) {
-            
-            twoNodeClient.del(basePath + '/test', { recursive: true }, function (err, success) {
-                
+                should(response.length).be.exactly(42)
+                return done()
+            })
+        })
+    })
+    describe('hdfs "getHomeDirectory"', function () {
+        it('works properly', function (done) {
+            const homeDirectory = '{"Path": "/user/username"}'
+            const urlPath = '/webhdfs/v1?op=gethomedirectory&user.name=webuser';
+            const namenodeRequest = nock(nodeOneBase)
+                .get(urlPath)
+                .reply(200, homeDirectory)
+            oneNodeClient.getHomeDirectory(function (err, response) {
                 should.not.exist(err);
-                should.exist(success);
-                
-                success.should.be.true;
-                
-                return done();
-                
-            });
-            
-        });
-        
-    });
-    
+                should(response).be.exactly('/user/username')
+                return done()
+            })
+        })
+    })
+    describe('hdfs "open"', function () {
+        it('works properly', function (done) {
+            const filePath = '/test/file'
+            const qs = '?op=open';
+            const namenodeRequest = nock(nodeOneBase)
+                .get(`/webhdfs/v1${filePath}${qs}`)
+                .reply(200, 'file contents!!')
+            oneNodeClient.open(filePath, function (err, status) {
+                should.not.exist(err);
+                should(status).be.exactly('file contents!!')
+                return done()
+            })
+        })
+    })
+    describe('hdfs "rename"', function () {
+        it('works properly', function (done) {
+            const filePath = '/test/file';
+            const newFilePath = '/new/test/file';
+            // const qs = `?op=rename&destination=${newFilePath}&user.name=webuser`;
+            const namenodeRequest = nock(nodeOneBase)
+                .put('/webhdfs/v1/test/file?op=rename&destination=%2Fnew%2Ftest%2Ffile&user.name=webuser')
+                .reply(200, {boolean: true})
+            oneNodeClient.rename(filePath, newFilePath, function (err, status) {
+                should.not.exist(err);
+                should(status).be.exactly(true)
+                return done()
+                //return
+            })
+        })
+    })
+    describe('hdfs "mkdirs"', function () {
+        it('works properly', function (done) {
+            const newDir = '/new/directory'
+            const qs = '?op=mkdirs&user.name=webuser';
+            const namenodeRequest = nock(nodeOneBase)
+                .put(`/webhdfs/v1${newDir}${qs}`)
+                .reply(200, {boolean: true})
+            oneNodeClient.mkdirs(newDir, function (err, response) {
+                should.not.exist(err);
+                should(response).be.exactly(true)
+                return done()
+                //return
+            })
+        })
+    })
+    describe('hdfs "append"', function () {
+        const datanode = 'http://datanode1.lan:50070'
+        const filePath = '/test/file'
+        const appendData = 'some append data'
+        const qs = '?op=append&user.name=webuser';
+        it('follows redirect properly', function (done) {
+            const namenodeRequest = nock(nodeOneBase)
+                .post(`/webhdfs/v1${filePath}${qs}`)
+                .reply(307, '', {location: `${datanode}/webhdfs/v1${filePath}${qs}`})
+            const datanodeRequest = nock(datanode)
+                .post(`/webhdfs/v1${filePath}${qs}`)
+                .reply(200, true)
+            oneNodeClient.append(filePath, appendData, function (err, response) {
+                should.not.exist(err);
+                should(response).be.exactly(true)
+                return done()
+            })
+        })
+    })
+    describe('hdfs "create"', function () {
+        const datanode = 'http://datanode1.lan:50070'
+        const filePath = '/test/file'
+        const appendData = 'some append data'
+        const qs = '?op=create&user.name=webuser';
+        it('follows redirect properly', function (done) {
+            const namenodeRequest = nock(nodeOneBase)
+                .put(`/webhdfs/v1${filePath}${qs}`)
+                .reply(307, '', {location: `${datanode}/webhdfs/v1${filePath}${qs}`})
+            const datanodeRequest = nock(datanode)
+                .put(`/webhdfs/v1${filePath}${qs}`)
+                .reply(201, '')
+            oneNodeClient.create(filePath, appendData, function (err, response) {
+                should.not.exist(err);
+                should(response).be.exactly(undefined)
+                return done()
+            })
+        })
+    })
 });


### PR DESCRIPTION
refs #14 

This will add an additional option `default_backoff_time_ms` (500ms default) for the starting backoff in the event of sequential transitions between the two namenodes in the `WebHDFSClient`. 

So far, I have tested this in the wild with a single process writing a fixed number of records to a file in HDFS in the following scenarios without errors or data loss:  
- Baseline test with no failover  
- Manual failover triggered through Cloudera Manager  
- Hard failover triggered by completely killing the HDFS container with the active namenode process. I did this about halfway through the job and left the namenode down for the remaining half of the job  
- Hard failover triggered by killing the HDFS container with the active namenode process and allowing it to restart and recover as the standby namenode. I followed this up with a manual failover as well as a second hard failover by killing the container again just for good measures with no problems  

The only scenario I have not tested with a real HDFS cluster is the `dead server` scenario. However, I was able to see the exponential backoff kicking in by setting up a basic `WebHDFSClient` client with bogus URLs for the namenodes and temporarily adding a couple of `console.log()`s to the `node-webhdfs` code.

I'll leave this as a WIP until I get some feedback on the changes and update `README.md` with the new option.